### PR TITLE
Adjust Margins and Font Properties for Meeting Spaces Card

### DIFF
--- a/app/components/Breadcrumbs.tsx
+++ b/app/components/Breadcrumbs.tsx
@@ -17,7 +17,7 @@ const Breadcrumbs: React.FC<BreadcrumbsProps> = ({ links }) => {
                 {links.map((item, index) => (
                     <Breadcrumb className="relative left-0" key={index}>
                         <BreadcrumbLink href={item.href}>
-                            <span>{item.text}</span>
+                            <span className="!no-underline">{item.text}</span>
                         </BreadcrumbLink>
                     </Breadcrumb>
                 ))}

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -16,7 +16,7 @@ export default function Index() {
             <CardGroup className="min-w-[30rem] max-w-[49rem]">
                 <Card>
                     <Header>
-                        <div className="object-contain">
+                        <div className="object-contain h-76">
                             <img
                                 alt="A room of people in attendance at a meeting"
                                 className="rounded-t-md"
@@ -24,47 +24,53 @@ export default function Index() {
                                 src="/meeting-spaces-header.jpg"
                             />
                         </div>
-                        <Breadcrumbs links={breadcrumbLinks} />
                     </Header>
-                    <CardHeader className="-mt-2">
-                        <h1 className="font usa-card__heading font-bold py-2">Meeting Spaces</h1>
-                        <p className="font-sans text-base-darker text-left">
-                            Austin Public Library Meeting Spaces are
-                            <strong className="font-bold"> free of charge</strong> and ideal for
-                            discussion groups, panels, and lectures. Both paper and online
-                            reservation requests are timestamped and processed in the order they are
-                            received.
-                        </p>
-                    </CardHeader>
-                    <div className="flex-col px-3">
-                        <Label htmlFor="reservation-select">Reserve Online</Label>
-                        <Select
-                            defaultValue="empty"
-                            id="reservation-select"
-                            name="reservation-select"
-                        >
-                            <option disabled value="empty">
-                                - Select -{" "}
-                            </option>
-                            <option value="non-profit">
-                                Room for Non-Profit/Non-Commercial Activity
-                            </option>
-                            <option value="business">Room for Business/Company Work</option>
-                        </Select>
-                        <div className="my-4">
-                            <strong>Reserve In-Person Instead</strong>
-                            <ul className="list-disc ml-4">
-                                <li>
-                                    <Link href="#">Printable Form (PDF)</Link>
-                                </li>
-                                <li>
-                                    <Link href="#">Sala de Reunión Forma de Solicitud</Link>
-                                </li>
-                            </ul>
+                    <div className="ml-5 mr-5">
+                        <div className="-mt-1 ml-1">
+                            <Breadcrumbs links={breadcrumbLinks} />
                         </div>
-                    </div>
-                    <div className="mx-4 mb-4">
-                        <MeetingRoomFAQ />
+                        <CardHeader className="-mt-3">
+                            <h1 className="font-sans text-[40px] usa-card__heading font-bold py-2">
+                                Meeting Spaces
+                            </h1>
+                            <p className="font-sans text-base-darker text-sans-xs">
+                                Austin Public Library Meeting Spaces are
+                                <strong className="font-bold"> free of charge</strong> and ideal for
+                                discussion groups, panels, and lectures. Both paper and online
+                                reservation requests are timestamped and processed in the order they
+                                are received.
+                            </p>
+                        </CardHeader>
+                        <div className="flex-col px-3">
+                            <Label htmlFor="reservation-select">Reserve Online</Label>
+                            <Select
+                                defaultValue="empty"
+                                id="reservation-select"
+                                name="reservation-select"
+                            >
+                                <option disabled value="empty">
+                                    - Select -{" "}
+                                </option>
+                                <option value="non-profit">
+                                    Room for Non-Profit/Non-Commercial Activity
+                                </option>
+                                <option value="business">Room for Business/Company Work</option>
+                            </Select>
+                            <div className="my-4">
+                                <strong>Reserve In-Person Instead</strong>
+                                <ul className="list-disc ml-4">
+                                    <li>
+                                        <Link href="#">Printable Form (PDF)</Link>
+                                    </li>
+                                    <li>
+                                        <Link href="#">Sala de Reunión Forma de Solicitud</Link>
+                                    </li>
+                                </ul>
+                            </div>
+                        </div>
+                        <div className="mx-4 mb-4">
+                            <MeetingRoomFAQ />
+                        </div>
                     </div>
                 </Card>
             </CardGroup>

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -16,7 +16,7 @@ export default function Index() {
             <CardGroup className="min-w-[30rem] max-w-[49rem]">
                 <Card>
                     <Header>
-                        <div className="object-contain h-76">
+                        <div className="object-contain">
                             <img
                                 alt="A room of people in attendance at a meeting"
                                 className="rounded-t-md"


### PR DESCRIPTION
# Pull Request

Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change.

---

This addresses some minor styling issues for [#21](https://github.com/orgs/APL-Innovation-Lab/projects/1/views/6?pane=issue&itemId=69438535)

Changes include:
- Adjust the "Meeting Spaces" heading text to be the correct font and font-size, per the [Figma Flow Map](https://www.figma.com/design/DMjN6uhMLOw7VZO3t4eqjd/APL-Meeting-Room?node-id=1225-43028&node-type=SYMBOL&t=b1U1b5tCjfcPtdGX-0).
- Adjust the left and right margins for the main content area
- Remove text-decorations for `<Breadcrumbs />` component links

**Type of change:**

-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] Refactor (non-breaking change which improves existing functionality)
-   [ ] Test (add missing tests or correct existing tests)
-   [ ] Chore (update to build tasks, package manager configs, etc; no production code change)
-   [ ] Documentation (update project documentation)

## Screenshots

Please take screenshots of the screens that are affected as a part of your pull request on both iOS and Android. Drag images into this PR and GitHub will generate an image link.

---
Max-Width
![desktop](https://github.com/user-attachments/assets/f57146d0-c72b-4750-93a4-8c6c83c7736d)

Min-Width
![mobile](https://github.com/user-attachments/assets/bbc81a0a-b8aa-4e4c-a532-6ba61a97d24a)

