### PR TITLE
Add pages for confirming booking cancellation

### DIFF
--- a/app/routes/cancellation-confirmation-page-meeting-room.tsx
+++ b/app/routes/cancellation-confirmation-page-meeting-room.tsx
@@ -1,30 +1,26 @@
-import { Button, Card, CardGroup, CardHeader, Link } from "@trussworks/react-uswds";
+import { Button, Card, CardGroup, Link } from "@trussworks/react-uswds";
 
 import { mergeMeta } from "~/lib/merge-meta";
 
-export const meta = mergeMeta(({ parentTitle }) => [{ title: `Cancellation page • Shared Room` }]);
+export const meta = mergeMeta(({ parentTitle }) => [{ title: `Cancellation Confirmation page • Meeting Room` }]);
 
-export default function CancellationPageSharedRoom() {
+// TODO: Eventually need to pass booking details data.
+export default function CancellationConfirmationPageMeetingRoom() {
     return (
         <div className="flex justify-center">
             <CardGroup className="min-w-[50rem] max-w-[49rem]">
                 <Card>
-                    <br />
-                    <br />
                     <div className="justify-center ml-5 mr-5">
-                        <CardHeader className="-mt-3">
-
-                        </CardHeader>
-
-                        <br />
+                        <h1 className="font-sans text-[40px] font-bold text-center">
+                            Canceled
+                        </h1>
                         <h3 className="font-sans text-sans-xs text-center">
-                            Are you sure you want to cancel your booking for the room below?
+                            The following has been canceled.
                         </h3>
-
                         <div className="flex-col px-3">
                             <div className="my-5">
                                 <h3 className="font-sans text-[22px] font-bold text-center">
-                                    Austin Central Library, Shared Learning #3
+                                    Carver Branch, #1
                                 </h3>
                                 <p className="font-sans text-sans-xs text-center">
                                     710 W Cesar Chavez St, Austin, TX 78702
@@ -36,9 +32,9 @@ export default function CancellationPageSharedRoom() {
                                 </p>
                                 <p className="font-sans text-sans-xs text-center">Capacity: 4</p>
                                 <br />
-
+                                <br />
                                 <div className="flex justify-center">
-                                    <Link href="cancellation-confirmation-page-shared-room">
+                                    <Link href="/">
                                         <Button
                                             className="font-sans text-sans-xs"
                                             style={{
@@ -51,24 +47,7 @@ export default function CancellationPageSharedRoom() {
                                             }}
                                             type="button"
                                         >
-                                            Yes, Cancel Reservation
-                                        </Button>
-                                    </Link>
-                                </div>
-                                <br />
-                                <div className="flex justify-center">
-                                    <Link href="/">
-                                        <Button
-                                            className="font-sans text-sans-xs usa-button usa-button--outline"
-                                            style={{
-                                                paddingTop: 15,
-                                                paddingBottom: 15,
-                                                paddingLeft: 35,
-                                                paddingRight: 35,
-                                            }}
-                                            type="button"
-                                        >
-                                            No, Back to Meeting Spaces
+                                            Back to Meeting Spaces
                                         </Button>
                                     </Link>
                                 </div>
@@ -76,14 +55,11 @@ export default function CancellationPageSharedRoom() {
                                 <br />
                                 <br />
                                 <br />
-                                <br />
-
                             </div>
                         </div>
                     </div>
                 </Card>
             </CardGroup>
-
         </div>
     );
 }

--- a/app/routes/cancellation-confirmation-page-shared-room.tsx
+++ b/app/routes/cancellation-confirmation-page-shared-room.tsx
@@ -1,26 +1,22 @@
-import { Button, Card, CardGroup, CardHeader, Link } from "@trussworks/react-uswds";
+import { Button, Card, CardGroup, Link } from "@trussworks/react-uswds";
 
 import { mergeMeta } from "~/lib/merge-meta";
 
-export const meta = mergeMeta(({ parentTitle }) => [{ title: `Cancellation page • Shared Room` }]);
+export const meta = mergeMeta(({ parentTitle }) => [{ title: `Cancellation Confirmation page • Shared Room` }]);
 
-export default function CancellationPageSharedRoom() {
+// TODO: Eventually need to pass booking details data.
+export default function CancellationConfirmationPageSharedRoom() {
     return (
         <div className="flex justify-center">
             <CardGroup className="min-w-[50rem] max-w-[49rem]">
                 <Card>
-                    <br />
-                    <br />
                     <div className="justify-center ml-5 mr-5">
-                        <CardHeader className="-mt-3">
-
-                        </CardHeader>
-
-                        <br />
+                        <h1 className="font-sans text-[40px] font-bold text-center">
+                            Canceled
+                        </h1>
                         <h3 className="font-sans text-sans-xs text-center">
-                            Are you sure you want to cancel your booking for the room below?
+                            The following has been canceled.
                         </h3>
-
                         <div className="flex-col px-3">
                             <div className="my-5">
                                 <h3 className="font-sans text-[22px] font-bold text-center">
@@ -36,9 +32,9 @@ export default function CancellationPageSharedRoom() {
                                 </p>
                                 <p className="font-sans text-sans-xs text-center">Capacity: 4</p>
                                 <br />
-
+                                <br />
                                 <div className="flex justify-center">
-                                    <Link href="cancellation-confirmation-page-shared-room">
+                                    <Link href="/">
                                         <Button
                                             className="font-sans text-sans-xs"
                                             style={{
@@ -51,24 +47,7 @@ export default function CancellationPageSharedRoom() {
                                             }}
                                             type="button"
                                         >
-                                            Yes, Cancel Reservation
-                                        </Button>
-                                    </Link>
-                                </div>
-                                <br />
-                                <div className="flex justify-center">
-                                    <Link href="/">
-                                        <Button
-                                            className="font-sans text-sans-xs usa-button usa-button--outline"
-                                            style={{
-                                                paddingTop: 15,
-                                                paddingBottom: 15,
-                                                paddingLeft: 35,
-                                                paddingRight: 35,
-                                            }}
-                                            type="button"
-                                        >
-                                            No, Back to Meeting Spaces
+                                            Back to Meeting Spaces
                                         </Button>
                                     </Link>
                                 </div>
@@ -77,13 +56,11 @@ export default function CancellationPageSharedRoom() {
                                 <br />
                                 <br />
                                 <br />
-
                             </div>
                         </div>
                     </div>
                 </Card>
             </CardGroup>
-
         </div>
     );
 }

--- a/app/routes/cancellation-page-meeting-room.tsx
+++ b/app/routes/cancellation-page-meeting-room.tsx
@@ -1,14 +1,16 @@
 import { Button, Card, CardGroup, CardHeader, Link } from "@trussworks/react-uswds";
+
 import { mergeMeta } from "~/lib/merge-meta";
+import { useNavigate } from "react-router";
 
 export const meta = mergeMeta(({ parentTitle }) => [{ title: `Cancellation page • Meeting Room` }]);
 
 export default function CancellationPageMeetingRoom() {
     return (
         <div className="flex justify-center">
-             <CardGroup className="min-w-[50rem] max-w-[49rem]">
+            <CardGroup className="min-w-[50rem] max-w-[49rem]">
                 <Card>
-                    
+
                     <div className="justify-center ml-5 mr-5">
                         <CardHeader className="-mt-3">
 
@@ -36,7 +38,7 @@ export default function CancellationPageMeetingRoom() {
                                 <br />
 
                                 <div className="flex justify-center">
-                                    <Link href="#">
+                                    <Link href="cancellation-confirmation-page-meeting-room">
                                         <Button
                                             className="font-sans text-sans-xs"
                                             style={{
@@ -55,7 +57,7 @@ export default function CancellationPageMeetingRoom() {
                                 </div>
                                 <br />
                                 <div className="flex justify-center">
-                                    <Link href="#">
+                                    <Link href="/">
                                         <Button
                                             className="font-sans text-sans-xs usa-button usa-button--outline"
                                             style={{


### PR DESCRIPTION
# List of changes made:
- Add two pages for displaying a cancellation confirmation message for a meeting room and a shared room
  - The details are hardcoded for now and eventually will be replaced with data from the cancellation page.
  - Pages follow the Jerri's design in the Figma.
- Modify the cancellation pages so that the _Cancel_ buttons route to the confirmation pages

# Type of PR
- New feature

# PR description
This PR adds the cancellation confirmation pages that appear when a user cancels their booking. There is one component each for the meeting room and shared room, but these may eventually be consolidated into one component.

- [] PR does not interfere with app functionality
- [] PR does not fail any tests

Related to #52

## Video of pages/flow
Meeting room:
<p align="center">
  <video width="400" src="https://github.com/user-attachments/assets/f9ad59db-0358-4f1a-b334-b1bac95e3427">
</p>

Shared room:
<p align="center">
  <video width="400" src="https://github.com/user-attachments/assets/13829d53-19c6-466b-9339-015622ff528a">
</p>